### PR TITLE
Add shared header and new landing colors

### DIFF
--- a/INDEX.HTML
+++ b/INDEX.HTML
@@ -8,16 +8,7 @@
 </head>
 <body class="bg-white text-gray-900 flex flex-col min-h-screen">
 
-  <header class="w-full px-6 py-4 flex justify-between items-center border-b border-gray-200 shadow-sm">
-    <h1 class="text-2xl font-bold text-indigo-600">ExpatWealth</h1>
-    <nav class="space-x-6 text-sm">
-      <a href="#features" class="hover:text-indigo-500">Features</a>
-      <a href="#about" class="hover:text-indigo-500">About</a>
-      <a href="#faq" class="hover:text-indigo-500">FAQ</a>
-      <a href="#pricing" class="hover:text-indigo-500">Pricing</a>
-      <a href="#contact" class="hover:text-indigo-500">Contact</a>
-    </nav>
-  </header>
+  <div id="global-header"></div>
 
   <main class="flex-grow text-center px-6">
     <section class="pt-20 pb-12">
@@ -122,6 +113,7 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script src="/header.js"></script>
 </body>
 </html>
 

--- a/dashboards.html
+++ b/dashboards.html
@@ -8,11 +8,7 @@
 </head>
 <body class="bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white font-sans">
 
-  <!-- Top Nav -->
-  <header class="bg-white dark:bg-gray-800 shadow p-4 flex justify-between items-center sticky top-0 z-50">
-    <h1 class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">ExpatWealth</h1>
-    <a href="/logout" class="text-sm bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded transition">Logout</a>
-  </header>
+  <div id="global-header"></div>
 
   <main class="p-6 space-y-12 max-w-6xl mx-auto">
 
@@ -138,6 +134,8 @@
       resultEl.textContent = `${amount} ${from} = ${data.converted} ${to}`;
     }
   </script>
+
+  <script src="/header.js"></script>
 
 </body>
 </html>

--- a/header.html
+++ b/header.html
@@ -1,0 +1,9 @@
+<header class="w-full px-6 py-4 flex justify-between items-center border-b border-gray-200 shadow-sm bg-white">
+  <h1 class="text-2xl font-bold text-blue-700">ExpatWealth</h1>
+  <nav class="space-x-6 text-sm">
+    <a href="/INDEX.HTML" class="hover:text-blue-500">Home</a>
+    <a href="/landing.html" class="hover:text-blue-500">App</a>
+    <a href="/signup.html" class="hover:text-blue-500">Sign Up</a>
+    <a href="/login.html" class="hover:text-blue-500">Log In</a>
+  </nav>
+</header>

--- a/header.js
+++ b/header.js
@@ -1,0 +1,8 @@
+fetch('/header.html')
+  .then(res => res.text())
+  .then(html => {
+    const container = document.getElementById('global-header');
+    if (container) {
+      container.innerHTML = html;
+    }
+  });

--- a/landing.html
+++ b/landing.html
@@ -9,7 +9,8 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body class="bg-gradient-to-r from-indigo-500 via-purple-500 to-pink-500 min-h-screen flex flex-col">
+<body class="bg-gradient-to-r from-blue-800 via-blue-700 to-blue-600 min-h-screen flex flex-col">
+  <div id="global-header"></div>
   <div id="root" class="flex-grow"></div>
 
   <script type="text/babel">
@@ -32,7 +33,7 @@
         <section className="text-center py-20 px-4">
           <h1 className="text-4xl md:text-6xl font-bold mb-4">Manage Your Expat Finances with Ease</h1>
           <p className="text-lg md:text-xl max-w-2xl mx-auto mb-8">Stay on top of your expenses, convert currencies effortlessly, and track your monthly burn rates worldwide.</p>
-          <a href="/signup.html" className="bg-white text-indigo-600 font-semibold px-8 py-3 rounded shadow hover:bg-gray-100">Get Started</a>
+          <a href="/signup.html" className="bg-white text-blue-600 font-semibold px-8 py-3 rounded shadow hover:bg-gray-100">Get Started</a>
         </section>
       );
     }
@@ -114,14 +115,14 @@
           <div className="max-w-5xl mx-auto grid gap-6 sm:grid-cols-2 md:grid-cols-3">
             {tiers.map((tier, idx) => (
               <div key={idx} className="border rounded-lg p-6 text-center shadow bg-gray-50">
-                <h3 className="text-xl font-semibold mb-2 text-indigo-600">{tier.title}</h3>
+                <h3 className="text-xl font-semibold mb-2 text-blue-600">{tier.title}</h3>
                 <p className="text-2xl font-bold mb-4">{tier.price}</p>
                 <ul className="mb-6 text-gray-600">
                   {tier.features.map((f, i) => (
                     <li key={i}>{f}</li>
                   ))}
                 </ul>
-                <button className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700">Choose</button>
+                <button className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700">Choose</button>
               </div>
             ))}
           </div>
@@ -133,7 +134,7 @@
       return (
         <section id="contact" className="py-16 px-4 bg-gray-100 text-gray-800">
           <h2 className="text-3xl font-bold text-center mb-4">Contact Us</h2>
-          <p className="text-center">Reach us at <a href="mailto:support@expatwealth.com" className="text-indigo-600 underline">support@expatwealth.com</a></p>
+          <p className="text-center">Reach us at <a href="mailto:support@expatwealth.com" className="text-blue-600 underline">support@expatwealth.com</a></p>
         </section>
       );
     }
@@ -153,5 +154,6 @@
 
     ReactDOM.createRoot(document.getElementById('root')).render(<App />);
   </script>
+  <script src="/header.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -8,13 +8,7 @@
 </head>
 <body class="bg-white text-gray-900 flex flex-col min-h-screen">
 
-  <header class="w-full px-6 py-4 flex justify-between items-center border-b border-gray-200 shadow-sm">
-    <h1 class="text-2xl font-bold text-indigo-600">ExpatWealth</h1>
-    <nav class="space-x-6 text-sm">
-      <a href="/index.html" class="hover:text-indigo-500">Home</a>
-      <a href="/signup.html" class="hover:text-indigo-500">Sign Up</a>
-    </nav>
-  </header>
+  <div id="global-header"></div>
 
   <main class="flex-grow flex items-center justify-center px-6">
     <div class="w-full max-w-md bg-white rounded shadow-md p-8 mt-12 mb-20">
@@ -53,6 +47,7 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script src="/header.js"></script>
 </body>
 </html>
 

--- a/signup.html
+++ b/signup.html
@@ -8,13 +8,7 @@
 </head>
 <body class="bg-white text-gray-900 flex flex-col min-h-screen">
 
-  <header class="w-full px-6 py-4 flex justify-between items-center border-b border-gray-200 shadow-sm">
-    <h1 class="text-2xl font-bold text-indigo-600">ExpatWealth</h1>
-    <nav class="space-x-6 text-sm">
-      <a href="/index.html" class="hover:text-indigo-500">Home</a>
-      <a href="#contact" class="hover:text-indigo-500">Contact</a>
-    </nav>
-  </header>
+  <div id="global-header"></div>
 
   <main class="flex-grow flex items-center justify-center px-6">
     <div class="w-full max-w-md bg-white rounded shadow-md p-8 mt-12 mb-20">
@@ -49,5 +43,6 @@
   <script>
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
+  <script src="/header.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- reuse a single header across all pages
- create `header.html` and `header.js` for dynamic header injection
- update `landing.html` with calmer blue gradient

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842215273f8832388fc19fd413a1990